### PR TITLE
Reset s:fuzzy for star-search

### DIFF
--- a/plugin/oblique.vim
+++ b/plugin/oblique.vim
@@ -475,6 +475,7 @@ function! s:star_search(backward, word, gv)
   call s:clear_highlight()
 
   let s:backward = a:backward
+  let s:fuzzy = 0
   let s:view = winsaveview()
   let s:ok = 1
   if a:gv


### PR DESCRIPTION
After a fuzzy-search (e.g. `z/foo`), a star-search (e.g. let `<cword>` be `bar`) results in `s:echo_pattern` outputting `F/foo` instead of `/\V\<bar\>`. Also, if all matches are removed from the buffer and the star-search is then repeated with `n` or `N`, `s:e486_fuzzy` outputs `E486: Fuzzy pattern not found: foo`.

Both of these issues are fixed by setting `s:fuzzy` to `0` in `s:star_search`.
