### PR TITLE
Always highlight current match after star-search

### DIFF
--- a/plugin/oblique.vim
+++ b/plugin/oblique.vim
@@ -216,10 +216,15 @@ endfunction
 
 function! s:finish_star()
   let s:prev = @/
+  silent! normal! N
+  let nview = winsaveview()
+  if nview.lnum != s:view.lnum || nview.col + len(s:star_word) <= s:view.col
+    silent! normal! n
+  endif
   call s:revert_showcmd()
+  call s:highlight_current_match()
   call winrestview(s:view)
   call s:set_autocmd()
-  call s:highlight_current_match()
   call s:echo_pattern('n')
   if len(s:star_word) < s:optval('min_length')
     call histdel('/', -1)


### PR DESCRIPTION
This aims to fix the second half of #3.

One potential issue: consider some text with overlapping matches, e.g. `a a a`.

Currently, `*` in visual mode with the second 2 a's selected (i.e. `a [a a]`) will result in `Search` highlighting `[a a] a` and `ObliqueCurrentMatch` highlighting `a [a a]` (and shadowing `Search`, so `Search` is really only visible for `[a ]a a`).

The new behavior would be to highlight `[a a] a` with `ObliqueCurrentMatch` (and of course `Search` under that, but invisible). Thus the current match is not the original selection, but it is the leftmost non-overlapping match, i.e. what would be jumped to with `n` or `N`.

This scenario seems rather obscure, however, so I'm not sure whether it matters much.
