### PR TITLE
Clear ObliqueCurrentMatch at beginning of s:finish

### DIFF
--- a/plugin/oblique.vim
+++ b/plugin/oblique.vim
@@ -132,6 +132,7 @@ endfunction
 
 function! s:finish()
   call s:revert_showcmd()
+  call s:clear()
   silent! call matchdelete(w:incsearch_id)
   silent! call matchdelete(w:current_incsearch_id)
   let last = s:strip_extra(@/)


### PR DESCRIPTION
After a successful search, a subsequent failed search will not clear `ObliqueCurrentMatch` from the successful one. This fixes that.